### PR TITLE
Added more teams to the list

### DIFF
--- a/ListApp/API/APICaller.swift
+++ b/ListApp/API/APICaller.swift
@@ -7,13 +7,40 @@
 
 import Foundation
 
+
+/// A "Fake" API call that gets all of the teams in the NBA.
+/// - Returns: An array of teams in the NBA.
 public func getTeamData() -> [Team] {
-    
-    
     return [
-        .init(id: 0, name: "Bulls", city: "Chicago", division: .east),
-        .init(id: 1, name: "Lakers", city: "Los Angeles", division: .west),
-        .init(id: 2, name: "Celtics", city: "Boston", division: .east)
+        Team(id: 1, name: "Hawks", city: "Atlanta", division: .southeast, conference: .eastern, fullName: "Atlanta Hawks", primaryColor: "Red"),
+        Team(id: 2, name: "Celtics", city: "Boston", division: .atlantic, conference: .eastern, fullName: "Boston Celtics", primaryColor: "Green"),
+        Team(id: 3, name: "Nets", city: "Brooklyn", division: .atlantic, conference: .eastern, fullName: "Brooklyn Nets", primaryColor: "Black"),
+        Team(id: 4, name: "Hornets", city: "Charlotte", division: .southeast, conference: .eastern, fullName: "Charlotte Hornets", primaryColor: "Teal"),
+        Team(id: 5, name: "Bulls", city: "Chicago", division: .central, conference: .eastern, fullName: "Chicago Bulls", primaryColor: "Red"),
+        Team(id: 6, name: "Cavaliers", city: "Cleveland", division: .central, conference: .eastern, fullName: "Cleveland Cavaliers", primaryColor: "Wine"),
+        Team(id: 7, name: "Mavericks", city: "Dallas", division: .southwest, conference: .western, fullName: "Dallas Mavericks", primaryColor: "Blue"),
+        Team(id: 8, name: "Nuggets", city: "Denver", division: .northwest, conference: .western, fullName: "Denver Nuggets", primaryColor: "Navy"),
+        Team(id: 9, name: "Pistons", city: "Detroit", division: .central, conference: .eastern, fullName: "Detroit Pistons", primaryColor: "Blue"),
+        Team(id: 10, name: "Warriors", city: "Golden State", division: .pacific, conference: .western, fullName: "Golden State Warriors", primaryColor: "Yellow"),
+        Team(id: 11, name: "Rockets", city: "Houston", division: .southwest, conference: .western, fullName: "Houston Rockets", primaryColor: "Red"),
+        Team(id: 12, name: "Pacers", city: "Indiana", division: .central, conference: .eastern, fullName: "Indiana Pacers", primaryColor: "Navy"),
+        Team(id: 13, name: "Clippers", city: "Los Angeles", division: .pacific, conference: .western, fullName: "LA Clippers", primaryColor: "Red"),
+        Team(id: 14, name: "Lakers", city: "Los Angeles", division: .pacific, conference: .western, fullName: "Los Angeles Lakers", primaryColor: "Purple"),
+        Team(id: 15, name: "Grizzlies", city: "Memphis", division: .southwest, conference: .western, fullName: "Memphis Grizzlies", primaryColor: "Blue"),
+        Team(id: 16, name: "Heat", city: "Miami", division: .southeast, conference: .eastern, fullName: "Miami Heat", primaryColor: "Red"),
+        Team(id: 17, name: "Bucks", city: "Milwaukee", division: .central, conference: .eastern, fullName: "Milwaukee Bucks", primaryColor: "Green"),
+        Team(id: 18, name: "Timberwolves", city: "Minnesota", division: .northwest, conference: .western, fullName: "Minnesota Timberwolves", primaryColor: "Blue"),
+        Team(id: 19, name: "Pelicans", city: "New Orleans", division: .southwest, conference: .western, fullName: "New Orleans Pelicans", primaryColor: "Navy"),
+        Team(id: 20, name: "Knicks", city: "New York", division: .atlantic, conference: .eastern, fullName: "New York Knicks", primaryColor: "Blue"),
+        Team(id: 21, name: "Thunder", city: "Oklahoma City", division: .northwest, conference: .western, fullName: "Oklahoma City Thunder", primaryColor: "Blue"),
+        Team(id: 22, name: "Magic", city: "Orlando", division: .southeast, conference: .eastern, fullName: "Orlando Magic", primaryColor: "Blue"),
+        Team(id: 23, name: "76ers", city: "Philadelphia", division: .atlantic, conference: .eastern, fullName: "Philadelphia 76ers", primaryColor: "Blue"),
+        Team(id: 24, name: "Suns", city: "Phoenix", division: .pacific, conference: .western, fullName: "Phoenix Suns", primaryColor: "Purple"),
+        Team(id: 25, name: "Trail Blazers", city: "Portland", division: .northwest, conference: .western, fullName: "Portland Trail Blazers", primaryColor: "Red"),
+        Team(id: 26, name: "Kings", city: "Sacramento", division: .pacific, conference: .western, fullName: "Sacramento Kings", primaryColor: "Purple"),
+        Team(id: 27, name: "Spurs", city: "San Antonio", division: .southwest, conference: .western, fullName: "San Antonio Spurs", primaryColor: "Silver"),
+        Team(id: 28, name: "Raptors", city: "Toronto", division: .atlantic, conference: .eastern, fullName: "Toronto Raptors", primaryColor: "Red"),
+        Team(id: 29, name: "Jazz", city: "Utah", division: .northwest, conference: .western, fullName: "Utah Jazz", primaryColor: "Navy"),
+        Team(id: 30, name: "Wizards", city: "Washington", division: .southeast, conference: .eastern, fullName: "Washington Wizards", primaryColor: "Red")
     ]
-    
 }

--- a/ListApp/ContentView.swift
+++ b/ListApp/ContentView.swift
@@ -23,8 +23,7 @@ struct ContentView: View {
                 List(teamArray) { team in
                     NavigationLink(destination: detailView(team: team)){
                         HStack{
-                            
-                            Text("\(team.city) \(team.name), \(team.division.rawValue)")
+                            Text("\(team.fullName)")
                         }
                     }
                 }

--- a/ListApp/Models/Team.swift
+++ b/ListApp/Models/Team.swift
@@ -7,16 +7,40 @@
 
 import Foundation
 
-public enum TeamDivision: String{
-    case east = "East"
-    case west = "West"
+/// The conference the team resides in.
+enum Conference: String {
+    case eastern = "Eastern"
+    case western = "Western"
 }
 
+/// The division the team resides in.
+enum Division: String {
+    case atlantic = "Atlantic"
+    case central = "Central"
+    case southeast = "Southeast"
+    case northwest = "Northwest"
+    case pacific = "Pacific"
+    case southwest = "Southwest"
+}
+
+/// A team in the NBA.
 public struct Team: Identifiable {
-    public var id: Int
-    
+    public let id: Int
     let name: String
     let city: String
-    let division: TeamDivision
-}
+    let division: Division
+    let conference: Conference
+    let fullName: String
+    let primaryColor: String
 
+    // Initialize a team with the given properties
+    init(id: Int, name: String, city: String, division: Division, conference: Conference, fullName: String, primaryColor: String) {
+        self.id = id
+        self.name = name
+        self.city = city
+        self.division = division
+        self.conference = conference
+        self.fullName = fullName
+        self.primaryColor = primaryColor
+    }
+}


### PR DESCRIPTION
### Description
Added all NBA teams to the list and included their full name, conference, division, etc.
Removed conference from the list.
Still need to add the icons for the teams inside of the list.

### Test Case

**Steps:**
1. Start up the application.
2. Navigate to the team list.
3. Observe that there is more than 3 teams in the list and that all NBA teams are now included.
